### PR TITLE
UI always shows the up-to-date list of players

### DIFF
--- a/server/static/index.html
+++ b/server/static/index.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <h1>
-            <a href="https://github.com/colyseus/colyseus-examples"></a>
+            <a href="https://github.com/colyseus/colyseus-examples">
                 <img
                     src="https://dl1.cbsistatic.com/i/2016/08/10/9efe9336-d20f-4f17-b79a-9d46644df6c3/bdd48ea08a22aaeaf554aff5b1cbc8e2/imgingest-5645171081042638537.png"
                     height="100"
@@ -33,7 +33,7 @@
             <input type="submit" value="send" />
         </form>
 
-        <hr/>
+        <hr />
 
         <strong>Players</strong><br />
 
@@ -46,31 +46,37 @@
                 location.protocol.replace("http", "ws") + "//" + host + (location.port ? ":" + location.port : "")
             );
 
-            let playersDiv = document.querySelector("#players");
-            const listPlayers = (function(players) {
-              for (let id in players) {
-                const player = players[id];
-                console.log(id, player);
+            const listPlayers = function(players) {
+                let playersDiv = document.querySelector("#players");
+                playersDiv.innerHTML = "";
+                for (let id in players) {
+                    const player = players[id];
+                    console.debug(id, player);
 
-                if (player.name && !playersDiv.querySelector(`#${id}`)) {
-                  let p = document.createElement("p");
-                  p.id = id;
-                  p.innerText = player.name;
-                  playersDiv.appendChild(p);
+                    // eventually i'd like to make this thing similar to jackbox, where it has some kind of placeholder
+                    // (maybe even animated) indicating the player has joined but is still setting their name
+                    if (!player.name) {
+                        player.name = "...";
+                    }
+
+                    let playerDiv = document.createElement("div");
+                    playerDiv.innerText = player.name;
+                    playerDiv.id = id;
+                    playersDiv.appendChild(playerDiv);
                 }
-              }
-            });
+            };
 
             client.joinOrCreate("my_room").then(room => {
                 console.log("joined");
                 room.onStateChange.once(function(state) {
-                    console.log("initial room state:", state);
+                    console.debug("initial room state:", state);
                     listPlayers(state.players);
                 });
 
                 // new room state
                 room.onStateChange(function(state) {
                     // this signal is triggered on each patch
+                    console.debug("new state from server:", state);
                     listPlayers(state.players);
                 });
 
@@ -87,10 +93,10 @@
 
                     let input = document.querySelector("#nameInput");
 
-                    console.log("sending new name to server:", input.value);
+                    console.debug("sending new name to server:", input.value);
 
                     // send data to room
-                    room.send({ command: "setName", params: { name: input.value }});
+                    room.send({ command: "setName", params: { name: input.value } });
 
                     // clear input
                     input.value = "";


### PR DESCRIPTION
Basically just deleted the old list before creating the new one. Nice thing about it is you don't have to check for the old one, you just always create a new list on state update.

When we eventually start using react for the front end, we can actually just store the state on the client side too, and react or redux or whatever will do all the work of deciding whether or not to update the list of players.

Also swapped most console.logs to debug, you can enable it in chrome by opening the console, clicking the dropdown, and clicking "verbose".

![image](https://user-images.githubusercontent.com/4218016/77851451-3d4aa280-71a7-11ea-995a-9044f190f257.png)
